### PR TITLE
Automate version stamping in GHA

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,35 @@
+name: Solid - Build and Test
+
+on: 
+  push:
+
+jobs:
+  build-and-test:
+    name: Build Debug and Run Tests
+    # note that the older .Net 4.6.1 isn't installed on windows-latest anymore
+    # see https://github.com/actions/runner-images/issues/5055
+    runs-on: windows-2019
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
+
+      - name: Cache NuGet packages
+        id: cache-nuget
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Restore
+        run: dotnet restore src/solid.sln
+      
+      - name: Build
+        run: dotnet build src/solid.sln --no-restore
+
+      - name: Run NUnit Tests
+        run: dotnet test output/net461/*Tests.dll  --filter "TestCategory != SkipOnCI" --no-build -- NUnit.TestOutputXml=TestResults

--- a/.github/workflows/installer-release.yml
+++ b/.github/workflows/installer-release.yml
@@ -1,43 +1,13 @@
-name: Solid - Build, Test, Installer, Release
+name: Solid - Build installer and create release
 
-on: 
+on:
   push:
+    tags:
+      - 'v*'  # Build an installer for commits that are tagged starting with 'v' e.g. v1.0
 
 jobs:
-  build-and-test:
-    name: Build Debug and Run Tests
-    # note that the older .Net 4.6.1 isn't installed on windows-latest anymore
-    # see https://github.com/actions/runner-images/issues/5055
-    runs-on: windows-2019
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: '0'
-
-      - name: Cache NuGet packages
-        id: cache-nuget
-        uses: actions/cache@v4
-        with:
-          path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
-          restore-keys: |
-            ${{ runner.os }}-nuget-
-
-      - name: Restore
-        run: dotnet restore src/solid.sln
-      
-      - name: Build
-        run: dotnet build src/solid.sln --no-restore
-
-      - name: Run NUnit Tests
-        run: dotnet test output/net461/*Tests.dll  --filter "TestCategory != SkipOnCI" --no-build -- NUnit.TestOutputXml=TestResults
-
   build-installer:
     name: Build Release And Make Installer
-    needs: build-and-test
-    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: windows-2019
 
     steps:
@@ -79,7 +49,6 @@ jobs:
   sign-installer:
     name: Sign SOLID installer
     needs: build-installer
-    if: startsWith(github.ref, 'refs/tags/v')
     uses: sillsdev/codesign/.github/workflows/sign.yml@v2
     with:
       artifact: SolidInstaller.exe
@@ -89,7 +58,6 @@ jobs:
   create-release:
     name: Create Release
     needs: sign-installer
-    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: windows-latest
 
     steps:

--- a/.github/workflows/installer-release.yml
+++ b/.github/workflows/installer-release.yml
@@ -20,6 +20,14 @@ jobs:
           echo "FULL_VERSION=${FULL_VERSION}" >> $GITHUB_ENV
         shell: bash
 
+      - name: Validate version format
+        run: |
+          if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Version format is incorrect. It should match N.N.N where N is an integer."
+            exit 1
+          fi
+        shell: bash
+
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/installer-release.yml
+++ b/.github/workflows/installer-release.yml
@@ -11,6 +11,15 @@ jobs:
     runs-on: windows-2019
 
     steps:
+      - name: Set VERSION (e.g. 1.0.0) and FULL_VERSION (e.g. 1.0.0-abcdef4)
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          FULL_VERSION="${VERSION}-${SHORT_SHA}"
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "FULL_VERSION=${FULL_VERSION}" >> $GITHUB_ENV
+        shell: bash
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -28,7 +37,22 @@ jobs:
       - name: Restore
         run: dotnet restore src/solid.sln
       
-      - name: Build
+      - name: Update AssemblyInfo.cs
+        run: |
+          $filePath = "C:\src\solid\src\SolidGui\Properties\AssemblyInfo.cs"
+          (Get-Content $filePath) -replace 'AssemblyVersion\(".*\)', "AssemblyVersion\(\"${{ env.VERSION }}.0\"\)" |
+          Set-Content $filePath
+          (Get-Content $filePath) -replace 'AssemblyFileVersion\(".*\)', "AssemblyFileVersion\(\"${{ env.VERSION }}.0\"\)" |
+          Set-Content $filePath
+          (Get-Content $filePath) -replace 'AssemblyInformationalVersion\(".*\)', "AssemblyInformationalVersion\(\"${{ env.FULL_VERSION }}\"\)" |
+          Set-Content $filePath
+        shell: powershell
+
+      - name: Verify Update
+        run: Get-Content "C:\src\solid\src\SolidGui\Properties\AssemblyInfo.cs"
+        shell: powershell
+      
+      - name: Build version ${{ env.VERSION }}
         run: dotnet build -c Release src/solid.sln --no-restore
       
       - name: List files and subdirectories
@@ -38,12 +62,12 @@ jobs:
         shell: powershell
 
       - name: Build Installer
-        run: iscc installer/setup.iss
+        run: iscc /DMyAppVersion=${{ env.VERSION }} installer/setup.iss
 
       - uses: actions/upload-artifact@v4
         with:
           name: SolidInstaller.exe
-          path: installer\Output\SolidInstaller.exe
+          path: installer\Output\SolidInstaller*.exe
           if-no-files-found: error
 
   sign-installer:
@@ -68,7 +92,7 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
-          files: SolidInstaller.exe
+          files: SolidInstaller*.exe
           body: |
             Release for version ${{ github.ref }}
           draft: true

--- a/installer/setup.iss
+++ b/installer/setup.iss
@@ -2,7 +2,11 @@
 EnableISX=true
 
 #define MyAppName "Solid"
+
+#ifndef MyAppVersion
 #define MyAppVersion "1.0.0"
+#endif
+
 #define MyAppPublisher "SIL International"
 #define MyAppURL "http://software.sil.org/solid"
 #define MyAppExeName "Solid.exe"
@@ -25,7 +29,7 @@ DisableReadyPage=yes
 DefaultGroupName={#MyAppName}
 DisableProgramGroupPage=yes
 LicenseFile=license.rtf
-OutputBaseFilename=SolidInstaller
+OutputBaseFilename=SolidInstaller-{AppVersion}
 Compression=lzma
 SolidCompression=yes
 ;WizardImageFile=compiler:WIZMODERNIMAGE-IS.BMP


### PR DESCRIPTION
This PR:

- splits the workflow into a build and test workflow and a build installer and release workflow.  This will help manage these separately in the future
- adds automation to GHA to determine the version number from the tag and stamp the AssemblyInfo.cs file and installer with the correct version
- enforces the version number via bash script

fixes #14 