### PR TITLE
remove invalid email from error reporting green screen

### DIFF
--- a/src/SolidGui/Program.cs
+++ b/src/SolidGui/Program.cs
@@ -95,7 +95,6 @@ namespace SolidGui
         {
             ExceptionHandler.Init(new WinFormsExceptionHandler());
             Logger.Init();
-            ErrorReport.Init("solid@projects.palaso.org");
         }
 
         private static void SetupUsageTracking()


### PR DESCRIPTION
fixes #11 

This removes the old invalid email address from the error reporting green screen.  Now, no email is shown in the dialog.  Users are expected to create a GitHub issue.

Before: 
![image](https://github.com/sillsdev/solid/assets/3444521/a4ea4bad-eee4-4c7f-b278-3d5273517987)


After:
![image](https://github.com/sillsdev/solid/assets/3444521/24da15c9-babb-4acf-bedf-c52baca53c9c)
