### PR TITLE
Fix some "nullable reference type" warnings

### DIFF
--- a/src/SolidGui/AppWritingSystems.cs
+++ b/src/SolidGui/AppWritingSystems.cs
@@ -10,14 +10,8 @@ namespace SolidGui
 {
     public class AppWritingSystems
     {
-        private static IWritingSystemRepository _sWritingSystemsRepository;
+        private static Lazy<IWritingSystemRepository> _sWritingSystemsRepository = new(() => GlobalWritingSystemRepository.Initialize());
 
-        public static IWritingSystemRepository WritingSystems
-        {
-            get
-            {
-                return _sWritingSystemsRepository ?? (_sWritingSystemsRepository = GlobalWritingSystemRepository.Initialize());
-            }
-        }
+        public static IWritingSystemRepository WritingSystems => _sWritingSystemsRepository.Value;
     }
 }

--- a/src/SolidGui/DataShapesDialog.cs
+++ b/src/SolidGui/DataShapesDialog.cs
@@ -18,7 +18,7 @@ namespace SolidGui
 {
     public partial class DataShapesDialog : Form
     {
-        private FindReplaceDialog _searchDialog;
+        private FindReplaceDialog? _searchDialog;
 
         public DataShapesDialog(FindReplaceDialog searchDialog, MainWindowPM mwp)
         {
@@ -34,9 +34,9 @@ namespace SolidGui
             _mainWindowPm = mwp;
         }
 
-        private MainWindowPM _mainWindowPm;
+        private MainWindowPM? _mainWindowPm;
 
-        private IEnumerable<SfmDictionary.DataShape> _shapes;
+        private IEnumerable<SfmDictionary.DataShape>? _shapes;
 
         private void _closeButton_Click(object sender, EventArgs e)
         {
@@ -166,7 +166,7 @@ WARNING: This moves trailing newlines too, and it will not work
 if any of the fields have hard-wrapped data.";
 
             RegexItem r = RegexItem.GetCustomRegex(sbFind.ToString(), sbReplace.ToString(), help, true);
-            _searchDialog.LaunchSearch(r);
+            _searchDialog?.LaunchSearch(r);
 
         }
 

--- a/src/SolidGui/DataValuesDialog.cs
+++ b/src/SolidGui/DataValuesDialog.cs
@@ -20,7 +20,7 @@ namespace SolidGui
             _mainWindowPm = mwp;
         }
 
-        private MainWindowPM _mainWindowPm;
+        private MainWindowPM? _mainWindowPm;
 
         private void _runButton_Click(object sender, EventArgs e)
         {
@@ -30,6 +30,7 @@ namespace SolidGui
         private void Run()
         {
             if (String.IsNullOrEmpty(_markersTextBox.Text.Trim())) return;
+            if (_mainWindowPm == null) return;
 
             int max = (int)maxNumericUpDown.Value;
 

--- a/src/SolidGui/MainWindowPM.cs
+++ b/src/SolidGui/MainWindowPM.cs
@@ -52,29 +52,21 @@ namespace SolidGui
         private static Regex _cleanUpNewlinesNonLinux;
         */
 
-
-        public MainWindowPM() 
+        static MainWindowPM()
         {
-            Initialize(new SfmDictionary()); // , new SolidSettings());
+            RegexOptions options = RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.Multiline;
+            _cleanUpIndents = new Regex(@"^[ \t]+\\", options);  //any line-initial spaces or tabs
+            _cleanUpClosers = new Regex(@" ?\\\w+\* ?", options);  //any closing tag, and possibly one space buffer around it
+            _cleanUpInferred = new Regex(@"^[ \t]*\\\+.*(\r|\r?\n)", options);  //any inferred marker (\+mrkr) and its value and newline (any leading whitespace)
+            _cleanUpSeparators = new Regex(@"\t", options);  // one tab
+            _cleanUpNewlines = new Regex(@"(\r?\n|\r)", options);  // one newline (\r\n or \n or \r)
         }
 
-        public override string ToString()
-        {
-            return string.Format("{0} {1} {2} {3} {4} {5} {6}",
-                _workingDictionary, _markerSettingsModel, _recordFilters, _warningFilterChooserModel, 
-                _navigatorModel, _sfmEditorModel, GetHashCode());
-        }
-
-        private static String TempDictionaryPath()
-        {
-            return Path.Combine(Path.GetTempPath(), "TempDictionary.db");
-        }
-
-        public void Initialize(SfmDictionary dict) // , SolidSettings settings)
+        public MainWindowPM()
         {
             _recordFilters = new RecordFilterSet();
-            _workingDictionary = dict;
-            // Settings = settings;
+            _workingDictionary = new SfmDictionary();
+            // Settings = new SolidSettings();
             _markerSettingsModel = new MarkerSettingsPM(this);
             _warningFilterChooserModel = new FilterChooserPM();
             _navigatorModel = new RecordNavigatorPM(this);
@@ -95,13 +87,18 @@ namespace SolidGui
             // and the choosers should listen to the nav so they can clear themselves as needed
             NavigatorModel.NavFilterChanged += WarningFilterChooserModel.OnNavFilterChanged;
             NavigatorModel.NavFilterChanged += MarkerSettingsModel.OnNavFilterChanged;
+        }
 
-            RegexOptions options = RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.Multiline;
-            _cleanUpIndents = new Regex(@"^[ \t]+\\", options);  //any line-initial spaces or tabs
-            _cleanUpClosers = new Regex(@" ?\\\w+\* ?", options);  //any closing tag, and possibly one space buffer around it
-            _cleanUpInferred = new Regex(@"^[ \t]*\\\+.*(\r|\r?\n)", options);  //any inferred marker (\+mrkr) and its value and newline (any leading whitespace)
-            _cleanUpSeparators = new Regex(@"\t", options);  // one tab
-            _cleanUpNewlines = new Regex(@"(\r?\n|\r)", options);  // one newline (\r\n or \n or \r)
+        public override string ToString()
+        {
+            return string.Format("{0} {1} {2} {3} {4} {5} {6}",
+                _workingDictionary, _markerSettingsModel, _recordFilters, _warningFilterChooserModel,
+                _navigatorModel, _sfmEditorModel, GetHashCode());
+        }
+
+        private static String TempDictionaryPath()
+        {
+            return Path.Combine(Path.GetTempPath(), "TempDictionary.db");
         }
 
         public MarkerSettingsPM MarkerSettingsModel

--- a/src/SolidGui/MainWindowPM.cs
+++ b/src/SolidGui/MainWindowPM.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
 using System.Text;
@@ -70,6 +71,24 @@ namespace SolidGui
             return Path.Combine(Path.GetTempPath(), "TempDictionary.db");
         }
 
+        // Modern C# (since .NET 6) warns about constructors not setting all fields, but isn't smart
+        // enough to know that this method sets those fields. So we have to help its analysis with the
+        // MemberNotNull] attribute, which informs the compiler that this method will set those members.
+        // Unfortunately, MemberNotNull is only available in .NET 5.0, so we also have to use an #if.
+#if NET5_0_OR_GREATER
+        [MemberNotNull(nameof(_recordFilters))]
+        [MemberNotNull(nameof(_workingDictionary))]
+        [MemberNotNull(nameof(_markerSettingsModel))]
+        [MemberNotNull(nameof(_warningFilterChooserModel))]
+        [MemberNotNull(nameof(_navigatorModel))]
+        [MemberNotNull(nameof(_sfmEditorModel))]
+        [MemberNotNull(nameof(_searchModel))]
+        [MemberNotNull(nameof(_cleanUpIndents))]
+        [MemberNotNull(nameof(_cleanUpClosers))]
+        [MemberNotNull(nameof(_cleanUpInferred))]
+        [MemberNotNull(nameof(_cleanUpSeparators))]
+        [MemberNotNull(nameof(_cleanUpNewlines))]
+#endif
         public void Initialize(SfmDictionary dict) // , SolidSettings settings)
         {
             _recordFilters = new RecordFilterSet();

--- a/src/SolidGui/MainWindowPM.cs
+++ b/src/SolidGui/MainWindowPM.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
 using System.Text;
@@ -71,24 +70,6 @@ namespace SolidGui
             return Path.Combine(Path.GetTempPath(), "TempDictionary.db");
         }
 
-        // Modern C# (since .NET 6) warns about constructors not setting all fields, but isn't smart
-        // enough to know that this method sets those fields. So we have to help its analysis with the
-        // MemberNotNull] attribute, which informs the compiler that this method will set those members.
-        // Unfortunately, MemberNotNull is only available in .NET 5.0, so we also have to use an #if.
-#if NET5_0_OR_GREATER
-        [MemberNotNull(nameof(_recordFilters))]
-        [MemberNotNull(nameof(_workingDictionary))]
-        [MemberNotNull(nameof(_markerSettingsModel))]
-        [MemberNotNull(nameof(_warningFilterChooserModel))]
-        [MemberNotNull(nameof(_navigatorModel))]
-        [MemberNotNull(nameof(_sfmEditorModel))]
-        [MemberNotNull(nameof(_searchModel))]
-        [MemberNotNull(nameof(_cleanUpIndents))]
-        [MemberNotNull(nameof(_cleanUpClosers))]
-        [MemberNotNull(nameof(_cleanUpInferred))]
-        [MemberNotNull(nameof(_cleanUpSeparators))]
-        [MemberNotNull(nameof(_cleanUpNewlines))]
-#endif
         public void Initialize(SfmDictionary dict) // , SolidSettings settings)
         {
             _recordFilters = new RecordFilterSet();

--- a/src/SolidGui/QuickFixer.cs
+++ b/src/SolidGui/QuickFixer.cs
@@ -187,7 +187,7 @@ namespace Solid.Engine
         {
             foreach (Record record in _dictionary.Records)
             {
-                SfmFieldModel fieldToCopy = null;
+                SfmFieldModel? fieldToCopy = null;
                 for (int i = 0; i < record.Fields.Count; i++)
                 {
                     SfmFieldModel field = record.Fields[i];
@@ -244,13 +244,13 @@ namespace Solid.Engine
             SolidSettings nullSettings = new SolidSettings();  // JMC: why a new bunch?
             foreach (RecordAddition addition in additions)
             {
-                string switchToCitationForm;
-                Record targetRecord = FindRecordByCitationFormOrLexemeForm(addition.targetHeadWord, out switchToCitationForm);
-                if (targetRecord == null)
+                string? switchToCitationForm;
+                Record? targetRecord = FindRecordByCitationFormOrLexemeForm(addition.targetHeadWord, out switchToCitationForm);
+                if (targetRecord is null)
                 {
                     targetRecord = FindRecordContainingVariantOrSubEntry(addition.targetHeadWord);
                 }
-                if (null == targetRecord)
+                if (targetRecord is null)
                 {
                     Record r = new Record();
                     var b = new StringBuilder();
@@ -309,7 +309,7 @@ namespace Solid.Engine
         }
 
 
-        private Record FindRecordByCitationFormOrLexemeForm(string form, out string switchToCitationForm)
+        private Record? FindRecordByCitationFormOrLexemeForm(string form, out string? switchToCitationForm)
         {
             switchToCitationForm = null;
             form = form.Trim();
@@ -348,7 +348,7 @@ namespace Solid.Engine
 
             return null;
         }
-        private Record FindRecordContainingVariantOrSubEntry(string form)
+        private Record? FindRecordContainingVariantOrSubEntry(string form)
         {
 
             foreach (Record record in _dictionary.Records)


### PR DESCRIPTION
This fixes some of the compiler warnings about nullable reference types that you get when you build this with a modern C# compiler. It doesn't fix nearly all of them, because I realized that a lot of these can't be easily fixed as long as the project is targeting `net461`. For example, this section of code produces a compiler warning on line 276 that `switchToCitationForm` might be null:

https://github.com/sillsdev/solid/blob/96dc3322a1b3514c43bedea07b354b3ba86b65f8/src/SolidGui/QuickFixer.cs#L269-L276

It's immediately obvious that `switchToCitationForm` cannot be null on line 276, but the compiler doesn't know that as long as the target framework is `net461`. That's because the annotations that tell the compiler "If this function returns true/false, then its parameter can/cannot be null" were added to library code sometime during the .NET Core / .NET 5 era, and the net461 framework libraries don't have those annotations. So the compiler can't infer anything about the nullness of the parameter to string.IsNullOrEmpty, and therefore it gives a warning. You could suppress it by using the `!` operator, as I did in this particular case, but doing that everywhere is tedious. And ultimately pointless, when switching to a more modern .NET target will end up fixing the issue anyway.

Therefore, I suggest postponing the rest of this work until after the code is switched to target a more modern version of .NET, say 6 or 8. At that point many of the compiler warnings will go away, and the ones that are left will be ones actually worth fixing.