### PR TITLE
run GHA on windows-latest

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -5,10 +5,8 @@ on:
 
 jobs:
   build-and-test:
-    name: Build Debug and Run Tests
-    # note that the older .Net 4.6.1 isn't installed on windows-latest anymore
-    # see https://github.com/actions/runner-images/issues/5055
-    runs-on: windows-2019
+    name: Build and run tests
+    runs-on: windows-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/installer-release.yml
+++ b/.github/workflows/installer-release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-installer:
     name: Build Release And Make Installer
-    runs-on: windows-2019
+    runs-on: windows-latest
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Previously, the GHA build needed to run on `windows-2019` due to using older tooling for .Net Framework.  Now that we are using `dotnet build` we can upgrade to running on `windows-latest`.