### PR TITLE
Upgrade from .NET 4.6.1 to 4.8.1

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -30,7 +30,7 @@ jobs:
         run: dotnet build src/solid.sln --no-restore
 
       - name: Run NUnit Tests
-        run: dotnet test output/net461/*Tests.dll  --filter "TestCategory != SkipOnCI" --no-build --logger "trx;LogFileName=test-results.trx"
+        run: dotnet test output/net481/*Tests.dll  --filter "TestCategory != SkipOnCI" --no-build --logger "trx;LogFileName=test-results.trx"
 
       - name: Test Report
         uses: dorny/test-reporter@v1

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Alternatively you can use Visual Studio and build / run tests there
 
 ### Running unit tests
 
-`dotnet test output/net461/*Tests.dll`
+`dotnet test output/net481/*Tests.dll`
 
 ### Create an installer locally
 GHA will do this for you, however if you need to test creating the installer locally:

--- a/installer/setup.iss
+++ b/installer/setup.iss
@@ -47,9 +47,9 @@ Name: {userdocs}\Solid Examples
 
 [Files]
 Source: ..\installer\isxdl.dll; Flags: dontcopy
-Source: ..\output\net461\solid.exe; DestDir: {app}; Flags: replacesameversion
-Source: ..\output\net461\*.dll; DestDir: {app}; Flags: replacesameversion
-Source: ..\output\net461\*.config; DestDir: {app}; Flags: replacesameversion
+Source: ..\output\net481\solid.exe; DestDir: {app}; Flags: replacesameversion
+Source: ..\output\net481\*.dll; DestDir: {app}; Flags: replacesameversion
+Source: ..\output\net481\*.config; DestDir: {app}; Flags: replacesameversion
 Source: ..\mappings\MappingXmlToHtml.xsl; DestDir: {app}\mappings
 Source: ..\mappings\LIFT.mappingSystem; DestDir: {app}\mappings
 Source: ..\mappings\FLEX.mappingSystem; DestDir: {app}\mappings
@@ -88,7 +88,7 @@ external 'isxdl_DownloadFiles@files:isxdl.dll stdcall';
 function isxdl_SetOption(Option, Value: String): Integer;
 external 'isxdl_SetOption@files:isxdl.dll stdcall';
 
-// Detect .NET framework 4.6.1 is missing
+// Detect .NET framework 4.8.1 is missing
 // See https://msdn.microsoft.com/en-us/library/hh925568(v=vs.110).aspx
 function DotNetIsMissing(): Boolean;
 var
@@ -96,7 +96,7 @@ var
   success: Boolean;
 begin
   success := RegQueryDWordValue(HKLM, 'SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full', 'Release', readVal);
-  success := success and (readVal >= 394254); // 394254 is the number for 4.6.1
+  success := success and (readVal >= 533320); // 533320 is the number for 4.8.1
   Result := not success;
 end;
 
@@ -108,7 +108,7 @@ begin
 
   // Check for required netfx installation
   if DotNetIsMissing() then begin
-      MsgBox('Solid needs the Microsoft .NET Framework 4.6.1 or greater to be installed by an Administrator', mbInformation, MB_OK);
+      MsgBox('Solid needs the Microsoft .NET Framework 4.8.1 or greater to be installed by an Administrator', mbInformation, MB_OK);
       Result := false;
     end;
 end;

--- a/src/SchemaEditor/app.config
+++ b/src/SchemaEditor/app.config
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup></configuration>

--- a/src/SchemaEditor/solid.csproj
+++ b/src/SchemaEditor/solid.csproj
@@ -1,4 +1,4 @@
-﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -9,6 +9,13 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Solid</RootNamespace>
     <AssemblyName>solid</AssemblyName>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>2.0</OldToolsVersion>
+    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -18,6 +25,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -26,6 +34,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -78,6 +87,7 @@
       <DependentUpon>Resources.resx</DependentUpon>
       <DesignTime>True</DesignTime>
     </Compile>
+    <None Include="app.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/src/SolidConsole/SolidConsole.csproj
+++ b/src/SolidConsole/SolidConsole.csproj
@@ -1,4 +1,4 @@
-﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="3.5">
+﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -11,9 +11,11 @@
     <AssemblyName>SolidConsole</AssemblyName>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
-    <OldToolsVersion>2.0</OldToolsVersion>
+    <OldToolsVersion>3.5</OldToolsVersion>
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
+    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -23,6 +25,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -31,6 +34,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -40,6 +44,9 @@
   <ItemGroup>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/SolidConsole/SolidConsole.sln
+++ b/src/SolidConsole/SolidConsole.sln
@@ -1,6 +1,8 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 9.00
-# Visual C# Express 2005
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.11.35208.52
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SolidConsole", "SolidConsole.csproj", "{2AE6670D-904B-42E3-AEBC-453649B1A6A3}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SolidConsoleTest", "..\SolidConsoleTest\SolidConsoleTest.csproj", "{89CEA606-4FAA-4E31-A20B-2C453E458236}"
@@ -22,5 +24,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {FD38C76B-CA2B-474E-A971-863499DD2E72}
 	EndGlobalSection
 EndGlobal

--- a/src/SolidConsole/app.config
+++ b/src/SolidConsole/app.config
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup></configuration>

--- a/src/SolidGui.Tests/SolidGui.Tests.csproj
+++ b/src/SolidGui.Tests/SolidGui.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net481</TargetFramework>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<IsPackable>false</IsPackable>

--- a/src/SolidGui/SolidGui.csproj
+++ b/src/SolidGui/SolidGui.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net481</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/SolidGui/app.config
+++ b/src/SolidGui/app.config
@@ -15,4 +15,4 @@
             </setting>
         </SolidGui.Properties.Settings>
     </userSettings>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup></configuration>

--- a/src/SolidGui/packages.config
+++ b/src/SolidGui/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net481" />
 </packages>


### PR DESCRIPTION
Hello @megahirt ,

here is a suggestion for a update from .NET 4.6.1 to 4.8.1.

Eventually you need the .NET 4.8.1 Developer Pack - see: https://dotnet.microsoft.com/en-us/download/dotnet-framework/net481.

The github-Action in my repository could build and also execute all tests without error. But please verify this.

If a merge to a feature-branch is prefered also let me know.

Any Feedback is welcome. :)

Greetings
Markus