### PR TITLE
Use the trusted-signing-service in installer-release.yml

### DIFF
--- a/.github/workflows/installer-release.yml
+++ b/.github/workflows/installer-release.yml
@@ -28,7 +28,9 @@ jobs:
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
           echo "FULL_VERSION=${FULL_VERSION}" >> $GITHUB_ENV
         shell: bash
+
       - name: set fake version for PR
+        shell: bash
         if: github.event_name == 'pull_request'
         run: |
           echo "VERSION=0.0.1" >> $GITHUB_ENV

--- a/.github/workflows/installer-release.yml
+++ b/.github/workflows/installer-release.yml
@@ -72,35 +72,17 @@ jobs:
       - name: Build Installer
         run: iscc /DMyAppVersion=${{ env.VERSION }} installer/setup.iss
 
-      - uses: actions/upload-artifact@v4
+      - name: Sign Installer
+        uses: sillsdev/codesign/trusted-signing-action@v3
         with:
-          name: SolidInstaller.exe
-          path: installer\Output\SolidInstaller*.exe
-          if-no-files-found: error
-
-  sign-installer:
-    name: Sign SOLID installer
-    needs: build-installer
-    uses: sillsdev/codesign/.github/workflows/sign.yml@v2
-    with:
-      artifact: SolidInstaller.exe
-    secrets:
-      certificate: ${{ secrets.CODESIGN_LSDEVSECTIGOEV }}
-
-  create-release:
-    name: Create Release
-    needs: sign-installer
-    runs-on: windows-latest
-
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: SolidInstaller.exe
+          credentials: ${{ secrets.TRUSTED_SIGNING_CREDENTIALS }}
+          files-folder: installer/Output
+          files-folder-filter: exe
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
-          files: SolidInstaller*.exe
+          files: installer/Output/SolidInstaller*.exe
           body: |
             Release for version ${{ github.ref }}
           draft: true

--- a/.github/workflows/installer-release.yml
+++ b/.github/workflows/installer-release.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - 'v*'  # Build an installer for commits that are tagged starting with 'v' e.g. v1.0
+  pull_request: 
+    branches: 
+      - main
 
 jobs:
   build-installer:
@@ -74,12 +77,14 @@ jobs:
 
       - name: Sign Installer
         uses: sillsdev/codesign/trusted-signing-action@v3
+        if: startsWith(github.ref, 'refs/tags/v')
         with:
           credentials: ${{ secrets.TRUSTED_SIGNING_CREDENTIALS }}
           files-folder: installer/Output
           files-folder-filter: SolidInstaller*.exe
 
       - name: Create Release
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
           files: installer/Output/SolidInstaller*.exe

--- a/.github/workflows/installer-release.yml
+++ b/.github/workflows/installer-release.yml
@@ -20,6 +20,7 @@ jobs:
           fetch-depth: '0'
 
       - name: Set VERSION (e.g. 1.0.0) and FULL_VERSION (e.g. 1.0.0-abcdef4)
+        if: github.event_name != 'pull_request'
         run: |
           VERSION="${GITHUB_REF#refs/tags/v}"
           SHORT_SHA=$(git rev-parse --short HEAD)
@@ -27,6 +28,11 @@ jobs:
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
           echo "FULL_VERSION=${FULL_VERSION}" >> $GITHUB_ENV
         shell: bash
+      - name: set fake version for PR
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "VERSION=0.0.1" >> $GITHUB_ENV
+          echo "FULL_VERSION=0.0.1-pr" >> $GITHUB_ENV
 
       - name: Validate version format
         run: |
@@ -77,14 +83,14 @@ jobs:
 
       - name: Sign Installer
         uses: sillsdev/codesign/trusted-signing-action@v3
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') && github.event_name != 'pull_request'
         with:
           credentials: ${{ secrets.TRUSTED_SIGNING_CREDENTIALS }}
           files-folder: installer/Output
           files-folder-filter: SolidInstaller*.exe
 
       - name: Create Release
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') && github.event_name != 'pull_request'
         uses: softprops/action-gh-release@v2
         with:
           files: installer/Output/SolidInstaller*.exe

--- a/.github/workflows/installer-release.yml
+++ b/.github/workflows/installer-release.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           credentials: ${{ secrets.TRUSTED_SIGNING_CREDENTIALS }}
           files-folder: installer/Output
-          files-folder-filter: exe
+          files-folder-filter: SolidInstaller*.exe
 
       - name: Create Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/installer-release.yml
+++ b/.github/workflows/installer-release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Validate version format
         run: |
           if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Error: Version format is incorrect. It should match N.N.N where N is an integer."
+            echo "Error: Version = '${VERSION}' format is incorrect. It should match N.N.N where N is an integer."
             exit 1
           fi
         shell: bash


### PR DESCRIPTION
Switch from the codesign v2 reusable workflow to the v3 trusted-signing-action.