### PR TITLE
Using UseShellExecute for Process.Start

### DIFF
--- a/src/SolidGui/MainWindowView.cs
+++ b/src/SolidGui/MainWindowView.cs
@@ -749,7 +749,7 @@ namespace SolidGui
 
             //Updating (JH) in 2017. I could not figure out where emails go, so to be safe, I'm changing to point to our standard website
             //which we can then keep up to date.
-            Process.Start("http://software.sil.org/solid/support/");
+            Process.Start(new ProcessStartInfo("http://software.sil.org/solid/support/") { UseShellExecute = true} );
         }
 
         private void _goFirstMenuItem_Click(object sender, EventArgs e)
@@ -799,7 +799,7 @@ namespace SolidGui
         {
             try
             {
-                Process.Start("Solid Documentation.pdf");
+                Process.Start(new ProcessStartInfo("Solid Documentation.pdf") { UseShellExecute = true });
             }
             catch (Exception err)
             {

--- a/src/SolidGui/QuickFixForm.cs
+++ b/src/SolidGui/QuickFixForm.cs
@@ -116,7 +116,7 @@ namespace SolidGui
                 File.WriteAllText(path, log, Encoding.UTF8);
                 log = _fixer.MakeEntriesForReferredItemsOfLv();
                 File.AppendAllText(path, log, Encoding.UTF8);
-                Process.Start(path);
+                Process.Start(new ProcessStartInfo(path) { UseShellExecute = true });
                 
             }
 
@@ -126,7 +126,7 @@ namespace SolidGui
                 string log = _fixer.PropagatePartOfSpeech();
                 string path = Path.GetTempFileName() + ".txt";
                 File.WriteAllText(path, log);
-                Process.Start(path);
+                Process.Start(new ProcessStartInfo(path) { UseShellExecute = true });
 
             } 
             DialogResult = System.Windows.Forms.DialogResult.OK;

--- a/src/SolidGui/SolidGui.csproj
+++ b/src/SolidGui/SolidGui.csproj
@@ -33,6 +33,7 @@
   <ItemGroup>
     <Reference Include="../../lib/GlacialList.dll" />
     <None Include="app.config" Pack="true" PackagePath="contentFiles\any\any\$(AssemblyTitle).dll.config" />
+    <Content Include="../../doc/Solid Manual/Solid Documentation.pdf" CopyToOutputDirectory="Always" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
.NET Core changed the default for shell execute (from true to false), which made any call to Process.Start() fail. This change fixes that.

I also added the PDF help documentation to the build output so that it can be opened with development builds.

Fixes #38 