### PR TITLE
Forced dialogs to open on the parent's monitor

### DIFF
--- a/src/SolidGui/MainWindowPM.cs
+++ b/src/SolidGui/MainWindowPM.cs
@@ -541,7 +541,7 @@ namespace SolidGui
 
         public void Export(int filterIndex, string destinationFilePath)
         {
-            using (var dlg = new ExportLogDialog())
+            using (var dlg = new ExportLogDialog() { StartPosition = FormStartPosition.CenterScreen })
             {
                 ExportFactory f = ExportFactory.Singleton();
                 IExporter exporter = f.CreateFromSettings(f.ExportSettings[filterIndex]);

--- a/src/SolidGui/MainWindowView.cs
+++ b/src/SolidGui/MainWindowView.cs
@@ -600,7 +600,7 @@ namespace SolidGui
 
         public string RequestTemplatePath(string dictionaryPath, bool wouldBeReplacingExistingSettings)  //Made public for the sake of Program.cs -JMC
         {
-            TemplateChooser chooser = new TemplateChooser(_mainWindowPM.Settings);
+            TemplateChooser chooser = new TemplateChooser(_mainWindowPM.Settings) { StartPosition = FormStartPosition.CenterScreen };
             chooser.CustomizedSolidDestinationName = Path.GetFileName(SolidSettings.GetSettingsFilePathFromDictionaryPath(dictionaryPath));
 
             string tmp = _mainWindowPM.DictionaryRealFilePath; //quick hack to enforce consistent behavior. -JMC Apr 2014
@@ -712,7 +712,7 @@ namespace SolidGui
         private void OnQuickFix(object sender, EventArgs e)
         {
             QuickFixer fixer = new QuickFixer(_mainWindowPM.WorkingDictionary);
-            var dlg = new QuickFixForm(fixer);
+            var dlg = new QuickFixForm(fixer) { StartPosition = FormStartPosition.CenterScreen };
             if (dlg.ShowDialog() == DialogResult.Cancel)
             {
                 return;
@@ -900,7 +900,10 @@ Notes:
         private void dataShapeInventoryToolStripMenuItem_Click(object sender, EventArgs e)
         {
             CloseDialog(_dataShapesDialog);
-            _dataShapesDialog = new DataShapesDialog(GetFindReplaceDialog(), _mainWindowPM);
+            _dataShapesDialog = new DataShapesDialog(GetFindReplaceDialog(), _mainWindowPM)
+            {
+                StartPosition = FormStartPosition.CenterScreen
+            };
             _dataShapesDialog.Show();
         }
 
@@ -908,7 +911,10 @@ Notes:
         private void dataValueInventoryToolStripMenuItem_Click(object sender, EventArgs e)
         {
             CloseDialog(_dataValuesDialog);
-            _dataValuesDialog = new DataValuesDialog(_mainWindowPM);
+            _dataValuesDialog = new DataValuesDialog(_mainWindowPM)
+            {
+                StartPosition = FormStartPosition.CenterScreen
+            };
             _dataValuesDialog.Show();
         }
 

--- a/src/SolidGui/MarkerSettings/MarkerSettingsListView.cs
+++ b/src/SolidGui/MarkerSettings/MarkerSettingsListView.cs
@@ -348,7 +348,7 @@ namespace SolidGui.MarkerSettings
             if (_markerSettingsDialog == null || _markerSettingsDialog.IsDisposed)
             {
                 _markerSettingsDialog = new MarkerSettingsDialog(_markerSettingsPm, marker, area);
-
+                _markerSettingsDialog.StartPosition = FormStartPosition.CenterScreen;
                 _markerSettingsDialog.Left = _xOfDialog;
                 _markerSettingsDialog.Top = _yOfDialog;
                 var myDelegate = new EventHandler(OnMarkerSettingPossiblyChanged);

--- a/src/SolidGui/Model/SfmDictionary.cs
+++ b/src/SolidGui/Model/SfmDictionary.cs
@@ -302,7 +302,7 @@ namespace SolidGui.Model
             }
             */
              
-            using (var dlg = new ProgressDialog())  // JMC:! Move this UI stuff elsewhere? E.g. unit tests that call this are popping up progress dialogs.
+            using (var dlg = new ProgressDialog() { StartPosition = FormStartPosition.CenterScreen })  // JMC:! Move this UI stuff elsewhere? E.g. unit tests that call this are popping up progress dialogs.
             {
                 dlg.Overview = "Loading and checking data...";
 

--- a/src/SolidGui/Setup/EncodingChooser.cs
+++ b/src/SolidGui/Setup/EncodingChooser.cs
@@ -69,7 +69,7 @@ namespace SolidGui.Setup
             string cp1252text = EncodingChecker.ReadLines(dictionaryPath, Encoding.GetEncoding(1252), 40);
             string utf8text = EncodingChecker.ReadLines(dictionaryPath, Encoding.UTF8, 40);
 
-            var encChooser = new EncodingChooser(dictionaryPath);
+            var encChooser = new EncodingChooser(dictionaryPath) { StartPosition = FormStartPosition.CenterScreen };
             encChooser.setAnalysis(utf8, cp1252);
             encChooser.setPreviews(utf8text, cp1252text);
             encChooser.ShowDialog();


### PR DESCRIPTION
This behavior (the default) may have changed with the upgrade to .NET8. I went through the usages of Show() and ShowDialog() and made a manual setting for cases where the owner didn't seem to be addressed.

Fixes #40 